### PR TITLE
task tablifying sb_replace_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE` and then specify the arguments `task_yml` (a filename for the task makefile created) and `out_dir` (the directory for putting the final target indicator).
+
 ```yaml
   sb_data:
     command: sb_replace_files(sbid,

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE` and then specify the arguments `task_yml` (a filename for the task makefile created) and `out_dir` (the directory for putting the final target indicator).
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE` and then specify the argument `task_yml` (a filename for the task makefile created).
 
 ```yaml
   sb_data:

--- a/README.md
+++ b/README.md
@@ -18,22 +18,16 @@ Need to have CRAN package `sbtools` installed
 
 ## remake.yml details
 
-This slim template is designed to keep everything in a single remake yaml. So all data munging, manipulation, and file writing happens there, in addition to the sciencebase uploads
+This slim template is designed to keep everything in a single remake yaml. So all data munging, manipulation, and file writing happens there, in addition to the sciencebase uploads.
 
 
-This is the single push to sciencebase, it does the xml (metadata) and data at the same time. Because the upload step uses an internal task table, you can specify all files that should be pushed to the same sbid at one time. Again, because the upload step uses an internal task table, data files aren't replaced everytime you fix a metadata typo or add information to a metadata field. 
+This is the single push to sciencebase, it does the xml (metadata) and data at the same time. Because the upload step uses an internal task table, you can specify all files that should be pushed to the same sbid at one time. Again, because the upload step uses an internal task table, data files aren't replaced everytime you fix a metadata typo or add information to a metadata field. The result of the sciencebase push step is a file with timestamps for when each file got pushed that can be checked into GitHub. Having the file with timestamps in GitHub will clearly show when updates were made and will render nicely without having to build the object target locally.
 ```yaml
 targets:
   all:
     depends:
-      - sb_posted
+      - log/sb_posted_files.csv
     
-```
-
-Here we define the data release location on sciencebase using the sciencebase identifier. 
-```yaml
-  sbid:
-    command: c(I('5faaac68d34eb413d5df1f22'))
 ```
 
 Read in (`st_read`) and manipulate data here. `extract_feature()` is from the `meddle` package and builds a list of structured spatial information for use in metadata files.
@@ -55,7 +49,6 @@ write final metadata files as you want them to appear in the data release.
     command: file.copy(from = "example_data/example_cars.csv", 
       to = target_name)
   
-
   out_data/spatial.zip:
     command: sf_to_zip(zip_filename = target_name, 
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
@@ -69,8 +62,9 @@ write final metadata files as you want them to appear in the data release.
 Push the files to sciencebase using the `sb_replace_files` function from `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`. You must also specify the file(s) where the `sb_replace_files` functions exist using the argument, `sources`. You can specify multiple files and a file hash file in one call to `sb_replace_files`. Currently, each `sb_replace_files` function can only push to one sbid. 
 
 ```yaml
-  sb_posted:
-    command: sb_replace_files(sbid,
+  log/sb_posted_files.csv:
+    command: sb_replace_files(filename = target_name, 
+      sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
       "out_xml/fgdc_metadata.xml",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE` and then specify the argument `task_yml` (a filename for the task makefile created).
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE`.
 
 ```yaml
   sb_data:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. To enable an internal task table method when using `sb_replace_files`, set the `use_task_table = TRUE`.
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`.
 
 ```yaml
   sb_data:

--- a/README.md
+++ b/README.md
@@ -62,21 +62,21 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`. You must also specify the file(s) where the sb_replace_files functions exist using the argument, `sb_upload_utils_src`. These task table instructions apply to `sb_render_post_xml`, too.
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`. You must also specify the file(s) where the sb_replace_files functions exist using the argument, `sources`. These task table instructions apply to `sb_render_post_xml`, too.
 
 ```yaml
   sb_data:
     command: sb_replace_files(sbid,
       "out_data/spatial.zip",
       "out_data/cars.csv",
-      sb_upload_utils_src = "src/sb_utils.R")
+      sources = "src/sb_utils.R")
       
   sb_xml:
     command: sb_render_post_xml(sbid,
       "in_text/text_data_release.yml",
       spatial_metadata, 
       xml_file = I("out_xml/fgdc_metadata.xml"),
-      sb_upload_utils_src = "src/sb_utils.R")
+      sources = "src/sb_utils.R")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -62,19 +62,21 @@ write final metadata files as you want them to appear in the data release.
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 ```
 
-Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`.
+Push the files to sciencebase using these two utility functions that are included in `src/sb_utils.R` of this repo template. If you are uploading many files at once using `sb_replace_files` (either in a file hash or just multiple files passed in through `...`), it is recommended to use a task table to do so. Internal task table methods are enabled by default. If you do not want to use an internal task table, set the `use_task_table = FALSE` when using `sb_replace_files`. You must also specify the file(s) where the sb_replace_files functions exist using the argument, `sb_upload_utils_src`. These task table instructions apply to `sb_render_post_xml`, too.
 
 ```yaml
   sb_data:
     command: sb_replace_files(sbid,
       "out_data/spatial.zip",
-      "out_data/cars.csv")
+      "out_data/cars.csv",
+      sb_upload_utils_src = "src/sb_utils.R")
       
   sb_xml:
     command: sb_render_post_xml(sbid,
       "in_text/text_data_release.yml",
       spatial_metadata, 
-      xml_file = I("out_xml/fgdc_metadata.xml"))
+      xml_file = I("out_xml/fgdc_metadata.xml"),
+      sb_upload_utils_src = "src/sb_utils.R")
 ```
 
 

--- a/remake.yml
+++ b/remake.yml
@@ -43,10 +43,12 @@ targets:
   sb_data:
     command: sb_replace_files(sbid,
       "out_data/spatial.zip",
-      "out_data/cars.csv")
+      "out_data/cars.csv",
+      sources = "src/sb_utils.R")
       
   sb_xml:
     command: sb_render_post_xml(sbid,
       "in_text/text_data_release.yml",
       spatial_metadata, 
-      xml_file = I("out_xml/fgdc_metadata.xml"))
+      xml_file = I("out_xml/fgdc_metadata.xml"),
+      sources = "src/sb_utils.R")

--- a/remake.yml
+++ b/remake.yml
@@ -12,8 +12,7 @@ sources:
 targets:
   all:
     depends:
-      - sb_xml
-      - sb_data
+      - sb_posted
     
 
       
@@ -34,21 +33,19 @@ targets:
     command: file.copy(from = "example_data/example_cars.csv", 
       to = target_name)
   
-
   out_data/spatial.zip:
     command: sf_to_zip(zip_filename = target_name, 
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 
-  
-  sb_data:
+  out_xml/fgdc_metadata.xml:
+    command: render(filename = target_name,
+      "in_text/text_data_release.yml",
+      spatial_metadata)
+    
+  sb_posted:
     command: sb_replace_files(sbid,
       "out_data/spatial.zip",
       "out_data/cars.csv",
+      "out_xml/fgdc_metadata.xml",
       sources = "src/sb_utils.R")
       
-  sb_xml:
-    command: sb_render_post_xml(sbid,
-      "in_text/text_data_release.yml",
-      spatial_metadata, 
-      xml_file = I("out_xml/fgdc_metadata.xml"),
-      sources = "src/sb_utils.R")

--- a/remake.yml
+++ b/remake.yml
@@ -15,10 +15,6 @@ targets:
       - sb_posted
     
 
-      
-  sbid:
-    command: c(I('5faaac68d34eb413d5df1f22'))
-
   sf_spatial_data:
     command: st_read('example_data/example_shapefile/example_shapefile.shp')
     depends:
@@ -42,8 +38,9 @@ targets:
       "in_text/text_data_release.yml",
       spatial_metadata)
     
-  sb_posted:
-    command: sb_replace_files(sbid,
+  log/sb_posted_files.csv:
+    command: sb_replace_files(filename = target_name, 
+      sbid = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
       "out_xml/fgdc_metadata.xml",

--- a/remake.yml
+++ b/remake.yml
@@ -1,6 +1,8 @@
 packages:
   - tidyverse
   - meddle # at least v0.0.12
+  - scipiper
+  - readr
   - dssecrets
   - sbtools
   - sf
@@ -12,7 +14,7 @@ sources:
 targets:
   all:
     depends:
-      - sb_posted
+      - log/sb_posted_files.csv
     
 
   sf_spatial_data:
@@ -40,7 +42,7 @@ targets:
     
   log/sb_posted_files.csv:
     command: sb_replace_files(filename = target_name, 
-      sbid = I('5faaac68d34eb413d5df1f22'),
+      sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
       "out_xml/fgdc_metadata.xml",

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -89,7 +89,7 @@ do_item_replace_tasks <- function(sb_id, files, sources) {
     packages = c('sbtools', 'scipiper', 'dplyr'),
     sources = sources,
     final_targets = final_target,
-    finalize_funs = "combine_upload_times",
+    finalize_funs = "bind_rows",
     as_promises = FALSE)
   
   # Build the tasks
@@ -120,8 +120,4 @@ upload_and_record <- function(sb_id, file) {
   
   # Then record when it happened and return that as an obj
   return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
-}
-
-combine_upload_times <- function(...) {
-  bind_rows(list(...))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -54,8 +54,6 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
 
 # Helper function to create a task_table for the files that need to be pushed to SB
 do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
-  # Define task table rows
-  tasks <- basename(files)
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(
@@ -70,7 +68,7 @@ do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
   
   # Create the task plan
   task_plan <- create_task_plan(
-    task_names = tasks,
+    task_names = files, # Define task table rows
     task_steps = list(sb_push),
     final_steps = c('push_file_to_sb'),
     add_complete = FALSE)

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -76,7 +76,7 @@ do_item_replace_tasks <- function(sb_id, files) {
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
-    packages = c('sbtools', 'scipiper', 'purrr'),
+    packages = c('sbtools', 'scipiper', 'purrr', 'dplyr'),
     final_targets = final_target,
     finalize_funs = "combine_upload_times",
     as_promises = FALSE)

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -7,7 +7,7 @@
 #' `do_item_replace_tasks`, `upload_and_record`, and `combine_upload_times` are defined. It 
 #' might be easier to put them all in the same file.
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sources = c()){
+sb_replace_files <- function(filename, sb_id, ..., file_hash, use_task_table = TRUE, sources = c()){
   
   files <- c(...)
   
@@ -19,11 +19,11 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   stopifnot(length(files) > 0)
 
   if(use_task_table) {
-    do_item_replace_tasks(sb_id, files, sources)
+    out_log <- do_item_replace_tasks(sb_id, files, sources)
   } else {
-    upload_and_record(sb_id, file = files)
+    out_log <- upload_and_record(sb_id, file = files)
   }
-  
+  write_csv(out_log, filename)
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -11,34 +11,17 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   
   files <- c(...)
   
-  # Throw error if there are no files given to push
-  stopifnot(length(files) > 0 | !missing(file_hash))
-  
-  # Keep login check here as well as in `upload_and_record` in case the task table
-  # method is not used
-  if (!sbtools::is_logged_in()){
-    sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
-    sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
-  }
-  
-  hashed_filenames <- c()
   if (!missing(file_hash)){
-    hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
-    if(use_task_table) {
-      do_item_replace_tasks(sb_id, hashed_filenames, sources)
-    } else {
-      for (file in hashed_filenames){
-        item_replace_files(sb_id, files = file)
-      }
-    }
+    files <- c(files, names(yaml.load_file(file_hash))) %>% sort() 
   }
-  
-  if (length(files) > 0){
-    if(use_task_table) {
-      do_item_replace_tasks(sb_id, files, sources)
-    } else {
-      item_replace_files(sb_id, files = files)
-    }
+
+  # Throw error if there are no files given to push
+  stopifnot(length(files) > 0)
+
+  if(use_task_table) {
+    do_item_replace_tasks(sb_id, files, sources)
+  } else {
+    upload_and_record(sb_id, file = files)
   }
   
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -82,7 +82,7 @@ do_item_replace_tasks <- function(sb_id, files, sb_upload_utils_src) {
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
-    packages = c('sbtools', 'scipiper', 'purrr', 'dplyr'),
+    packages = c('sbtools', 'scipiper', 'dplyr'),
     sources = sb_upload_utils_src,
     final_targets = final_target,
     finalize_funs = "combine_upload_times",
@@ -119,5 +119,5 @@ upload_and_record <- function(sb_id, file) {
 }
 
 combine_upload_times <- function(...) {
-  purrr::reduce(list(...), bind_rows)
+  bind_rows(list(...))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -78,7 +78,7 @@ do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
-    packages = c('sbtools'),
+    packages = c('sbtools', 'scipiper'),
     final_targets = final_target,
     as_promises = FALSE)
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -92,5 +92,5 @@ upload_and_record <- function(sb_id, file) {
   timestamp_chr <- format(timestamp, "%Y-%m-%d %H:%M %Z")
   
   # Then record when it happened and return that as an obj
-  return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
+  return(tibble(filepath = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -8,6 +8,11 @@
 #' 
 sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task_yml, out_dir){
   
+  files <- c(...)
+  
+  # Throw error if there are no files given to push
+  stopifnot(length(files) > 0 | !missing(file_hash))
+  
   if (!sbtools::is_logged_in()){
     sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
     sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
@@ -25,7 +30,6 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task
     }
   }
   
-  files <- c(...)
   if (length(files) > 0){
     if(use_task_table) {
       do_item_replace_tasks(files, sb_id, task_yml, out_dir)

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -78,12 +78,12 @@ do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
-    include = 'remake.yml',
     packages = c('sbtools'),
-    final_targets = final_target)
+    final_targets = final_target,
+    as_promises = FALSE)
   
   # Build the tasks
   loop_tasks(task_plan = task_plan, task_makefile = task_yml, num_tries = 3)
   
-  return(remake::fetch(sprintf("%s_promise", basename(final_target)), remake_file=task_yml))
+  return(remake::fetch(final_target, remake_file=task_yml))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -37,7 +37,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   
 }
 
-sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
+sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE){
   
   if (is.null(xml_file)){
     xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))
@@ -45,7 +45,7 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
   
   render(filename = xml_file, ...)
   
-  sb_replace_files(sb_id = sb_id, xml_file)
+  sb_replace_files(sb_id = sb_id, xml_file, use_task_table)
   
 }
 

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -95,8 +95,12 @@ upload_and_record <- function(sb_id, file) {
   # First, upload the file
   item_replace_files(sb_id, file)
   
+  timestamp <- Sys.time()
+  attr(timestamp, "tzone") <- "UTC"
+  timestamp_chr <- format(timestamp, "%Y-%m-%d %H:%M")
+  
   # Then record when it happened and return that as an obj
-  return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = Sys.time()))
+  return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
 }
 
 combine_upload_times <- function(...) {

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -19,7 +19,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   if (!missing(file_hash)){
     hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
     if(use_task_table) {
-      do_item_replace_tasks(hashed_filenames, sb_id)
+      do_item_replace_tasks(sb_id, hashed_filenames)
     } else {
       for (file in hashed_filenames){
         item_replace_files(sb_id, files = file)
@@ -29,7 +29,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   
   if (length(files) > 0){
     if(use_task_table) {
-      do_item_replace_tasks(files, sb_id)
+      do_item_replace_tasks(sb_id, files)
     } else {
       item_replace_files(sb_id, files = files)
     }
@@ -50,7 +50,7 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB
-do_item_replace_tasks <- function(files, sb_id) {
+do_item_replace_tasks <- function(sb_id, files) {
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -7,7 +7,7 @@
 #' `do_item_replace_tasks`, `upload_and_record`, and `combine_upload_times` are defined. It 
 #' might be easier to put them all in the same file.
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sources){
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sources = c()){
   
   files <- c(...)
   
@@ -43,7 +43,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   
 }
 
-sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE, sources){
+sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE, sources = c()){
   
   if (is.null(xml_file)){
     xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -69,7 +69,7 @@ do_item_replace_tasks <- function(sb_id, files, sources) {
     },
     command = function(task_name, ...){
       sprintf("upload_and_record(I('%s'), '%s')", sb_id, 
-              filter(task_df, task_name == task_name) %>% pull(filepath))
+              filter(task_df, task_name == !!task_name) %>% pull(filepath))
     } 
   )
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -30,13 +30,14 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
 do_item_replace_tasks <- function(sb_id, files, sources) {
   
   # Define task table rows
-  task_df <- tibble(filepath = files) %>% mutate(task_name = paste0('uploaded_file_', row_number()))
+  task_df <- tibble(filepath = files) %>% 
+    mutate(task_name = sprintf('sb_%s_%s_file', sb_id, basename(filepath)))
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(
     step_name = 'push_file_to_sb',
     target_name = function(task_name, step_name, ...){
-      sprintf("%s_pushed_to_sb", task_name)
+      task_name
     },
     command = function(task_name, ...){
       sprintf("upload_and_record(I('%s'), '%s')", sb_id, 
@@ -53,7 +54,8 @@ do_item_replace_tasks <- function(sb_id, files, sources) {
   
   # Create the task remakefile
   task_yml <- "file_upload_tasks.yml"
-  final_target <- "upload_timestamps"
+  final_target <- sprintf("upload_%s_timestamps", sb_id)
+  
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -1,9 +1,9 @@
 
 #' @param use_task_table logical specifying whether to call `do_item_replace_tasks`
 #' which will create a task_table of the files to push to ScienceBase. This prevents them
-#' all from failing if one fails.
+#' all from failing if one fails. Defaults to `TRUE`.
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE){
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   
   files <- c(...)
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -112,7 +112,7 @@ upload_and_record <- function(sb_id, file) {
   
   timestamp <- Sys.time()
   attr(timestamp, "tzone") <- "UTC"
-  timestamp_chr <- format(timestamp, "%Y-%m-%d %H:%M")
+  timestamp_chr <- format(timestamp, "%Y-%m-%d %H:%M %Z")
   
   # Then record when it happened and return that as an obj
   return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -2,9 +2,8 @@
 #' @param use_task_table logical specifying whether to call `do_item_replace_tasks`
 #' which will create a task_table of the files to push to ScienceBase. This prevents them
 #' all from failing if one fails.
-#' @param task_yml only needed if `use_task_table = TRUE`; task makefile name
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task_yml){
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE){
   
   files <- c(...)
   
@@ -20,7 +19,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task
   if (!missing(file_hash)){
     hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
     if(use_task_table) {
-      do_item_replace_tasks(hashed_filenames, sb_id, task_yml)
+      do_item_replace_tasks(hashed_filenames, sb_id)
     } else {
       for (file in hashed_filenames){
         item_replace_files(sb_id, files = file)
@@ -30,7 +29,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task
   
   if (length(files) > 0){
     if(use_task_table) {
-      do_item_replace_tasks(files, sb_id, task_yml)
+      do_item_replace_tasks(files, sb_id)
     } else {
       item_replace_files(sb_id, files = files)
     }
@@ -51,7 +50,7 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB
-do_item_replace_tasks <- function(files, sb_id, task_yml) {
+do_item_replace_tasks <- function(files, sb_id) {
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(
@@ -72,6 +71,7 @@ do_item_replace_tasks <- function(files, sb_id, task_yml) {
     add_complete = FALSE)
   
   # Create the task remakefile
+  task_yml <- "file_upload_tasks.yml"
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
@@ -81,4 +81,6 @@ do_item_replace_tasks <- function(files, sb_id, task_yml) {
   # Build the tasks
   loop_tasks(task_plan = task_plan, task_makefile = task_yml, num_tries = 3)
   
+  # Remove the temporary task makefile for uploading the files to ScienceBase
+  file.remove(task_yml)
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -43,18 +43,6 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   
 }
 
-sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE, sources = c()){
-  
-  if (is.null(xml_file)){
-    xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))
-  }
-  
-  render(filename = xml_file, ...)
-  
-  sb_replace_files(sb_id = sb_id, xml_file, use_task_table, sources)
-  
-}
-
 # Helper function to create a task_table for the files that need to be pushed to SB
 do_item_replace_tasks <- function(sb_id, files, sources) {
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -62,7 +62,7 @@ do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
       sprintf("%s_pushed_to_sb", task_name)
     },
     command = function(task_name, ...){
-      sprintf("item_replace_files('%s', '%s')", sb_id, task_name)
+      sprintf("item_replace_files(I('%s'), '%s')", sb_id, task_name)
     } 
   )
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -74,16 +74,13 @@ do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
     add_complete = FALSE)
   
   # Create the task remakefile
-  final_target <- sprintf("%s/%s_files_uploaded.ind", out_dir, gsub(".yml", "", basename(task_yml)))
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,
     packages = c('sbtools', 'scipiper'),
-    final_targets = final_target,
     as_promises = FALSE)
   
   # Build the tasks
   loop_tasks(task_plan = task_plan, task_makefile = task_yml, num_tries = 3)
   
-  return(remake::fetch(final_target, remake_file=task_yml))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -10,6 +10,8 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   # Throw error if there are no files given to push
   stopifnot(length(files) > 0 | !missing(file_hash))
   
+  # Keep login check here as well as in `upload_and_record` in case the task table
+  # method is not used
   if (!sbtools::is_logged_in()){
     sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
     sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
@@ -92,6 +94,14 @@ do_item_replace_tasks <- function(sb_id, files) {
 }
 
 upload_and_record <- function(sb_id, file) {
+  
+  # First verify that you are logged into SB. Need to do this for each task that calls 
+  # `upload_and_record` in case there are any long-running uploads that timeout the session.
+  if (!sbtools::is_logged_in()){
+    sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
+    sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
+  }
+  
   # First, upload the file
   item_replace_files(sb_id, file)
   

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -2,8 +2,12 @@
 #' @param use_task_table logical specifying whether to call `do_item_replace_tasks`
 #' which will create a task_table of the files to push to ScienceBase. This prevents them
 #' all from failing if one fails. Defaults to `TRUE`.
+#' @param sb_upload_utils_src filepath(s) for where all of the functions that do the sb file
+#' uploading live (`sb_replace_files`, `sb_render_post_xml`, `do_item_replace_tasks`, 
+#' `upload_and_record`, and `combine_upload_times`). It might be easier to put them all in
+#' the same file.
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sb_upload_utils_src = "sb_utils.R"){
   
   files <- c(...)
   
@@ -21,7 +25,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   if (!missing(file_hash)){
     hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
     if(use_task_table) {
-      do_item_replace_tasks(sb_id, hashed_filenames)
+      do_item_replace_tasks(sb_id, hashed_filenames, sb_upload_utils_src)
     } else {
       for (file in hashed_filenames){
         item_replace_files(sb_id, files = file)
@@ -31,7 +35,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   
   if (length(files) > 0){
     if(use_task_table) {
-      do_item_replace_tasks(sb_id, files)
+      do_item_replace_tasks(sb_id, files, sb_upload_utils_src)
     } else {
       item_replace_files(sb_id, files = files)
     }
@@ -39,7 +43,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE){
   
 }
 
-sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE){
+sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE, sb_upload_utils_src = "sb_utils.R"){
   
   if (is.null(xml_file)){
     xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))
@@ -47,12 +51,12 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRU
   
   render(filename = xml_file, ...)
   
-  sb_replace_files(sb_id = sb_id, xml_file, use_task_table)
+  sb_replace_files(sb_id = sb_id, xml_file, use_task_table, sb_upload_utils_src)
   
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB
-do_item_replace_tasks <- function(sb_id, files) {
+do_item_replace_tasks <- function(sb_id, files, sb_upload_utils_src) {
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(
@@ -79,6 +83,7 @@ do_item_replace_tasks <- function(sb_id, files) {
     task_plan = task_plan,
     makefile = task_yml,
     packages = c('sbtools', 'scipiper', 'purrr', 'dplyr'),
+    sources = sb_upload_utils_src,
     final_targets = final_target,
     finalize_funs = "combine_upload_times",
     as_promises = FALSE)

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -1,4 +1,12 @@
-sb_replace_files <- function(sb_id, ..., file_hash){
+
+#' @param use_task_table logical specifying whether to call `do_item_replace_tasks`
+#' which will create a task_table of the files to push to ScienceBase. This prevents them
+#' all from failing if one fails.
+#' @param task_yml only needed if `use_task_table = TRUE`; task makefile name
+#' @param out_dir only needed if `use_task_table = TRUE`; path to the directory where 
+#' final target indicators from the task_makefile should go
+#' 
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task_yml, out_dir){
   
   if (!sbtools::is_logged_in()){
     sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
@@ -8,13 +16,22 @@ sb_replace_files <- function(sb_id, ..., file_hash){
   hashed_filenames <- c()
   if (!missing(file_hash)){
     hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
-    for (file in hashed_filenames){
-      item_replace_files(sb_id, files = file)
+    if(use_task_table) {
+      do_item_replace_tasks(hashed_filenames, sb_id, task_yml, out_dir)
+    } else {
+      for (file in hashed_filenames){
+        item_replace_files(sb_id, files = file)
+      }
     }
   }
+  
   files <- c(...)
   if (length(files) > 0){
-    item_replace_files(sb_id, files = files)
+    if(use_task_table) {
+      do_item_replace_tasks(files, sb_id, task_yml, out_dir)
+    } else {
+      item_replace_files(sb_id, files = files)
+    }
   }
   
 }
@@ -29,4 +46,42 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
   
   sb_replace_files(sb_id = sb_id, xml_file)
   
+}
+
+# Helper function to create a task_table for the files that need to be pushed to SB
+do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
+  # Define task table rows
+  tasks <- basename(files)
+  
+  # Define task table columns
+  sb_push <- scipiper::create_task_step(
+    step_name = 'push_file_to_sb',
+    target_name = function(task_name, step_name, ...){
+      sprintf("%s_pushed_to_sb", task_name)
+    },
+    command = function(task_name, ...){
+      sprintf("item_replace_files('%s', '%s')", sb_id, task_name)
+    } 
+  )
+  
+  # Create the task plan
+  task_plan <- create_task_plan(
+    task_names = tasks,
+    task_steps = list(sb_push),
+    final_steps = c('push_file_to_sb'),
+    add_complete = FALSE)
+  
+  # Create the task remakefile
+  final_target <- sprintf("%s/%s_files_uploaded.ind", out_dir, gsub(".yml", "", basename(task_yml)))
+  create_task_makefile(
+    task_plan = task_plan,
+    makefile = task_yml,
+    include = 'remake.yml',
+    packages = c('sbtools'),
+    final_targets = final_target)
+  
+  # Build the tasks
+  loop_tasks(task_plan = task_plan, task_makefile = task_yml, num_tries = 3)
+  
+  return(remake::fetch(sprintf("%s_promise", basename(final_target)), remake_file=task_yml))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -3,10 +3,8 @@
 #' which will create a task_table of the files to push to ScienceBase. This prevents them
 #' all from failing if one fails.
 #' @param task_yml only needed if `use_task_table = TRUE`; task makefile name
-#' @param out_dir only needed if `use_task_table = TRUE`; path to the directory where 
-#' final target indicators from the task_makefile should go
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task_yml, out_dir){
+sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task_yml){
   
   files <- c(...)
   
@@ -22,7 +20,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task
   if (!missing(file_hash)){
     hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
     if(use_task_table) {
-      do_item_replace_tasks(hashed_filenames, sb_id, task_yml, out_dir)
+      do_item_replace_tasks(hashed_filenames, sb_id, task_yml)
     } else {
       for (file in hashed_filenames){
         item_replace_files(sb_id, files = file)
@@ -32,7 +30,7 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = FALSE, task
   
   if (length(files) > 0){
     if(use_task_table) {
-      do_item_replace_tasks(files, sb_id, task_yml, out_dir)
+      do_item_replace_tasks(files, sb_id, task_yml)
     } else {
       item_replace_files(sb_id, files = files)
     }
@@ -53,7 +51,7 @@ sb_render_post_xml <- function(sb_id, ..., xml_file = NULL){
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB
-do_item_replace_tasks <- function(files, sb_id, task_yml, out_dir) {
+do_item_replace_tasks <- function(files, sb_id, task_yml) {
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(


### PR DESCRIPTION
This is for #1. The idea is that you can use the argument `use_task_table` to control whether or not you want the task table method used. If you leave the new arguments as-is, `sb_replace_files` will function as it currently does (this means that no changes are required to existing use of `sb_replace_files` if this is merged). 