### PR TITLE
use `zip::zip` instead of `utils::zip`

### DIFF
--- a/src/file_utils.R
+++ b/src/file_utils.R
@@ -12,6 +12,6 @@ sf_to_zip <- function(zip_filename, sf_object, layer_name){
     filter(str_detect(string = filename, pattern = layer_name)) %>% pull(filename)
   
   setwd(dsn)
-  zip(file.path(cdir, zip_filename), files = files_to_zip)
+  zip::zip(file.path(cdir, zip_filename), files = files_to_zip)
   setwd(cdir)
 }


### PR DESCRIPTION
I always run into an error when `zip` is called in this pipeline, I think because I don't have a zip program per the language below (despite having Rtools installed). From `?utils::zip`:

> On a Unix-alike, the default for zip will by default use the value of R_ZIPCMD, which is set in ‘etc/Renviron’ if an unzip command was found during configuration. On Windows, the default relies on a zip program (for example that from Rtools) being in the path.