### PR TITLE
sb_replace_files to sb_replace_files_log

### DIFF
--- a/remake.yml
+++ b/remake.yml
@@ -44,6 +44,6 @@ targets:
       sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
-      sources = "src/sb_utils.R",
-      "out_xml/fgdc_metadata.xml")
+      "out_xml/fgdc_metadata.xml",
+      sources = "src/sb_utils.R")
       

--- a/remake.yml
+++ b/remake.yml
@@ -44,5 +44,6 @@ targets:
       sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
+      sources = "src/sb_utils.R",
       "out_xml/fgdc_metadata.xml")
       

--- a/remake.yml
+++ b/remake.yml
@@ -40,10 +40,9 @@ targets:
       spatial_metadata)
     
   log/sb_posted_files.csv:
-    command: sb_replace_files(filename = target_name, 
+    command: sb_replace_files_log(filename = target_name, 
       sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
-      "out_xml/fgdc_metadata.xml",
-      sources = "src/sb_utils.R")
+      "out_xml/fgdc_metadata.xml")
       


### PR DESCRIPTION
replacing sb_replace_files with sb_replace_files_log. The function seems to have a bug where it uploads the log file to SB (instead of saving it in the log file) and also pushes `sb_utils.R` to SB. This update seems to fix both of those issues. Issue #14 