### PR TITLE
Need `yaml` package in order for `sb_replace_files()` to work with the `file_hash` arg

### DIFF
--- a/remake.yml
+++ b/remake.yml
@@ -5,6 +5,7 @@ packages:
   - readr
   - sbtools
   - sf
+  - yaml
 
 sources:
   - src/sb_utils.R


### PR DESCRIPTION
Discovered while working on lakes data release